### PR TITLE
@testable caused CL build to fail with

### DIFF
--- a/CoPilotTests/DocClientServerTests.swift
+++ b/CoPilotTests/DocClientServerTests.swift
@@ -10,7 +10,6 @@ import Cocoa
 import XCTest
 import Nimble
 import FeinstrukturUtils
-@testable import CoPilot
 
 
 let words = [


### PR DESCRIPTION
```
Redundant conformance of 'Patch' to protocol 'SequenceType'
Redundant conformance of 'Operation' to protocol 'CustomStringConvertible'
```

Tests run from the command line now:

xcodebuild -scheme CoPilot test
...
Test Suite 'All tests' passed at 2015-06-27 12:06:27.577.
     Executed 43 tests, with 0 failures (0 unexpected) in 9.978 (10.002) seconds
*\* TEST SUCCEEDED **
