### PR TITLE
Fixes crash on subscribe

### DIFF
--- a/CoPilot.xcodeproj/project.pbxproj
+++ b/CoPilot.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		5A3013BD1B02978D003403FA /* FeinstrukturUtils.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5AD1E8751AE2A2BC0017CEEE /* FeinstrukturUtils.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		5A3013BF1B0297DD003403FA /* libPocketSocket-OSX.dylib in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5AB35B8E1AF22F1C00AF2F22 /* libPocketSocket-OSX.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		5A3013C11B0297DD003403FA /* DiffMatchPatch.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5AD1E7F91AE26ABD0017CEEE /* DiffMatchPatch.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5A3134D01B4C33F3000D83E3 /* issue_36_server.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5A3134CF1B4C33F3000D83E3 /* issue_36_server.txt */; };
+		5A3134DD1B4C3400000D83E3 /* issue_36_client.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5A3134DC1B4C3400000D83E3 /* issue_36_client.txt */; };
 		5A4B411E1AF3C71400BEC7BF /* DocClientServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4B411D1AF3C71400BEC7BF /* DocClientServerTests.swift */; };
 		5A4D7D9D1AF363FB005E0294 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4D7D9C1AF363FB005E0294 /* Command.swift */; };
 		5A4D7D9E1AF363FB005E0294 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4D7D9C1AF363FB005E0294 /* Command.swift */; };
@@ -266,6 +268,8 @@
 		5A0983CF1AE39E5B001ADB1F /* Diff.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Diff.swift; sourceTree = "<group>"; };
 		5A0983E41AE39F68001ADB1F /* CoPilot-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CoPilot-Bridging-Header.h"; sourceTree = "<group>"; };
 		5A17D91B1AF3CF9100429B79 /* new_playground.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = new_playground.txt; sourceTree = "<group>"; };
+		5A3134CF1B4C33F3000D83E3 /* issue_36_server.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = issue_36_server.txt; sourceTree = "<group>"; };
+		5A3134DC1B4C3400000D83E3 /* issue_36_client.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = issue_36_client.txt; sourceTree = "<group>"; };
 		5A4B411D1AF3C71400BEC7BF /* DocClientServerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocClientServerTests.swift; sourceTree = "<group>"; };
 		5A4D7D9C1AF363FB005E0294 /* Command.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		5A4D7DAA1AF366B1005E0294 /* CommandTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandTests.swift; sourceTree = "<group>"; };
@@ -365,6 +369,8 @@
 				5A17D91B1AF3CF9100429B79 /* new_playground.txt */,
 				5A6A69951B034E7A00F718C5 /* test_a.txt */,
 				5A6A69971B034E8E00F718C5 /* test_b.txt */,
+				5A3134DC1B4C3400000D83E3 /* issue_36_client.txt */,
+				5A3134CF1B4C33F3000D83E3 /* issue_36_server.txt */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -741,7 +747,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5A3134D01B4C33F3000D83E3 /* issue_36_server.txt in Resources */,
 				5A6A69961B034E7A00F718C5 /* test_a.txt in Resources */,
+				5A3134DD1B4C3400000D83E3 /* issue_36_client.txt in Resources */,
 				5A6A69981B034E8E00F718C5 /* test_b.txt in Resources */,
 				5A17D91C1AF3CF9100429B79 /* new_playground.txt in Resources */,
 			);

--- a/CoPilot/Diff.swift
+++ b/CoPilot/Diff.swift
@@ -123,26 +123,24 @@ extension Operation: CustomStringConvertible {
 
 
 func adjustPos(position: Position, patch: Patch) -> Position {
-    if position < patch.start1 {
+    if patch.start1 > position {
         return position
     } else {
         var posInPatch = position - patch.start1
         var diffPointer: Position = 0
         for diff in patch {
-            if posInPatch <= diffPointer {
-                return patch.start1 + posInPatch
-            } else {
-                let diffSize = Position((diff.text as NSString).length)
+            let diffSize = Position((diff.text as NSString).length)
 
-                switch diff.operation {
-                case .DiffEqual:
-                    diffPointer += diffSize
-                case .DiffDelete:
-                    posInPatch -= Position( min(diffSize, posInPatch) )
-                case .DiffInsert:
-                    posInPatch += Position(diffSize)
+            switch diff.operation {
+            case .DiffEqual:
+                diffPointer += diffSize
+                if diffPointer > posInPatch {
+                    return patch.start1 + posInPatch
                 }
-
+            case .DiffDelete:
+                posInPatch -= Position(min(diffSize, posInPatch))
+            case .DiffInsert:
+                posInPatch += diffSize
             }
         }
         return patch.start1 + posInPatch

--- a/CoPilot/Diff.swift
+++ b/CoPilot/Diff.swift
@@ -126,34 +126,29 @@ func adjustPos(position: Position, patch: Patch) -> Position {
     if position < patch.start1 {
         return position
     } else {
-        var x = position
-        var diffPointer = 0
+        var posInPatch = position - patch.start1
+        var diffPointer: Position = 0
         for diff in patch {
-            let posPointer = Int(x - patch.start1)
-            if diffPointer < posPointer {
-                x = adjustPos(x, diff: diff)
-            }
-            if diff.operation == .DiffEqual {
-                diffPointer += (diff.text as NSString).length
+            if posInPatch <= diffPointer {
+                return patch.start1 + posInPatch
+            } else {
+                let diffSize = Position((diff.text as NSString).length)
+
+                switch diff.operation {
+                case .DiffEqual:
+                    diffPointer += diffSize
+                case .DiffDelete:
+                    posInPatch -= Position( min(diffSize, posInPatch) )
+                case .DiffInsert:
+                    posInPatch += Position(diffSize)
+                }
+
             }
         }
-        return x
+        return patch.start1 + posInPatch
     }
 }
 
-
-func adjustPos(position: Position, diff: Diff) -> Position {
-    let diffSize = (diff.text as NSString).length
-    
-    switch diff.operation {
-    case .DiffEqual:
-        return position
-    case .DiffDelete:
-        return Position( max(Int(position) - diffSize, 0) )
-    case .DiffInsert:
-        return position + Position(diffSize)
-    }
-}
 
 
 func newPosition(currentPos: Position, patches: [Patch]) -> Position {

--- a/CoPilot/Utils.swift
+++ b/CoPilot/Utils.swift
@@ -42,6 +42,7 @@ extension NSTextStorage {
 
 
 extension String {
+
     subscript (r: Range<Int>) -> String {
         get {
             let startIndex = advance(self.startIndex, r.startIndex)
@@ -49,6 +50,13 @@ extension String {
             return self[Range(start: startIndex, end: endIndex)]
         }
     }
+
+    subscript (idx: Int) -> String {
+        get {
+            return self[idx..<idx+1]
+        }
+    }
+
 }
 
 

--- a/CoPilotTests/IssueTests.swift
+++ b/CoPilotTests/IssueTests.swift
@@ -21,7 +21,8 @@ class IssueTests: XCTestCase {
     }
 
 
-    // https://bitbucket.org/feinstruktur/copilot/issue/7/crash-when-cursor-at-end-and-receiving-an
+    // Crash when cursor at end and receiving an insertion
+    // https://github.com/feinstruktur/CoPilot/issues/7
     func test_issue_7() {
         let tv = NSTextView()
         let a = "123"
@@ -42,7 +43,8 @@ class IssueTests: XCTestCase {
     }
     
     
-    // https://bitbucket.org/feinstruktur/copilot/issue/8/insertion-point-not-preserved-when-emojis
+    // Insertion point not preserved when emojis appear
+    // https://github.com/feinstruktur/CoPilot/issues/8
     func test_issue_8() {
         // NSString based subsystems count 🔥 as 2 characters
         // we need to use (s as NSString).length instead of count(s) to stay in NSString's 'coordinate system'
@@ -55,7 +57,8 @@ class IssueTests: XCTestCase {
     }
 
 
-    // https://bitbucket.org/feinstruktur/copilot/issue/14/client-changes-get-nuked-by-server-always
+    // Client changes get nuked by server, always
+    // https://github.com/feinstruktur/CoPilot/issues/14
     func test_issue_14() {
         let serverDoc = Document("foo")
         self.server = DocServer(name: "server", document: serverDoc)

--- a/CoPilotTests/IssueTests.swift
+++ b/CoPilotTests/IssueTests.swift
@@ -92,9 +92,11 @@ class IssueTests: XCTestCase {
     func test_issue_36() {
         let server_txt = contentsOfFile(name: "issue_36_server", type: "txt")
         let client_txt = contentsOfFile(name: "issue_36_client", type: "txt")
-        expect(server_txt.characters.count) == 276
-        expect(client_txt.characters.count) == 86
-        let patches = computePatches(server_txt, b: client_txt)
+        let patches = computePatches(client_txt, b: server_txt)
+        expect(client_txt[15..<22]) == "var str"
+        expect(client_txt[15..<17]) == "va"
+        expect(client_txt[17..<19]) == "r "
+        expect(client_txt[19..<21]) == "st"
         expect(newPosition(15, patches: patches)) == 15
         expect(newPosition(16, patches: patches)) == 16
     }

--- a/CoPilotTests/IssueTests.swift
+++ b/CoPilotTests/IssueTests.swift
@@ -96,12 +96,21 @@ class IssueTests: XCTestCase {
         let server_txt = contentsOfFile(name: "issue_36_server", type: "txt")
         let client_txt = contentsOfFile(name: "issue_36_client", type: "txt")
         let patches = computePatches(client_txt, b: server_txt)
-        expect(client_txt[15..<22]) == "var str"
-        expect(client_txt[15..<17]) == "va"
-        expect(client_txt[17..<19]) == "r "
-        expect(client_txt[19..<21]) == "st"
-        expect(newPosition(15, patches: patches)) == 15
-        expect(newPosition(16, patches: patches)) == 16
+        expect(server_txt.characters.count) == 276
+        expect(client_txt.characters.count) == 86
+
+        for idx: Position in 0..<86 {
+            switch idx {
+            case 0..<15:
+                expect(newPosition(idx, patches: patches)) == idx
+            case 15..<54:
+                expect(newPosition(idx, patches: patches)) == 244
+            case 54..<86:
+                expect(newPosition(idx, patches: patches)) == 244 + (idx - 54)
+            default:
+                fail("unhandled index range")
+            }
+        }
     }
     
 }

--- a/CoPilotTests/IssueTests.swift
+++ b/CoPilotTests/IssueTests.swift
@@ -87,4 +87,16 @@ class IssueTests: XCTestCase {
     }
 
     
+    // Crashes on subscribe (Xcode7/OSX 10.11)
+    // https://github.com/feinstruktur/CoPilot/issues/36
+    func test_issue_36() {
+        let server_txt = contentsOfFile(name: "issue_36_server", type: "txt")
+        let client_txt = contentsOfFile(name: "issue_36_client", type: "txt")
+        expect(server_txt.characters.count) == 276
+        expect(client_txt.characters.count) == 86
+        let patches = computePatches(server_txt, b: client_txt)
+        expect(newPosition(15, patches: patches)) == 15
+        expect(newPosition(16, patches: patches)) == 16
+    }
+    
 }

--- a/CoPilotTests/issue_36_client.txt
+++ b/CoPilotTests/issue_36_client.txt
@@ -1,0 +1,8 @@
+
+import UIKit
+
+var str = "Hello, foo"
+let x = 5
+let y = 2
+let z = 4
+let asd = "sdfsd"

--- a/CoPilotTests/issue_36_server.txt
+++ b/CoPilotTests/issue_36_server.txt
@@ -1,0 +1,25 @@
+
+import UIKit
+
+enum MyError : ErrorType {
+case Error1
+}
+
+func doStuff(value: Int) throws -> String {
+if value == 1 {
+return "1"
+}
+throw MyError.Error1
+}
+
+func something() -> Int? {
+return nil
+}
+
+do {
+guard let x = something() else {
+throw MyError.Error1
+}
+print("in here")
+
+}


### PR DESCRIPTION
Fixes #36

Issue was a UInt underflow when the cursor position was sufficiently advanced in the client editor

Cleaned up the cursor adjustment code a bit on that occasion.
